### PR TITLE
fix: make donation updates fully optional

### DIFF
--- a/src/modules/donation/dtos/update-donation.dto.spec.ts
+++ b/src/modules/donation/dtos/update-donation.dto.spec.ts
@@ -1,0 +1,57 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateDonationDto } from './update-donation.dto';
+
+describe('UpdateDonationDto', () => {
+  it('permite payload vazio no update', async () => {
+    const dto = plainToInstance(UpdateDonationDto, {});
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('trata strings vazias como campos ausentes', async () => {
+    const dto = plainToInstance(UpdateDonationDto, {
+      category_id: '',
+      name: '',
+      description: '',
+      initial_quantity: '',
+      current_quantity: '',
+      donator_name: '',
+      gender: '',
+      size: '',
+      active: '',
+      available: '',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto).toEqual(
+      expect.objectContaining({
+        category_id: undefined,
+        name: undefined,
+        description: undefined,
+        initial_quantity: undefined,
+        current_quantity: undefined,
+        donator_name: undefined,
+        gender: undefined,
+        size: undefined,
+        active: undefined,
+        available: undefined,
+      })
+    );
+  });
+
+  it('converte numeros e booleanos enviados como string', async () => {
+    const dto = plainToInstance(UpdateDonationDto, {
+      initial_quantity: '10',
+      current_quantity: '4',
+      active: 'false',
+      available: 'true',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.initial_quantity).toBe(10);
+    expect(dto.current_quantity).toBe(4);
+    expect(dto.active).toBe(false);
+    expect(dto.available).toBe(true);
+  });
+});

--- a/src/modules/donation/dtos/update-donation.dto.ts
+++ b/src/modules/donation/dtos/update-donation.dto.ts
@@ -1,19 +1,94 @@
-import { PartialType } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsBoolean, IsNumber, IsOptional } from 'class-validator';
-import { CreateDonationDto } from './create-donation.dto';
+import { Transform } from 'class-transformer';
+import {
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
 
-export class UpdateDonationDto extends PartialType(CreateDonationDto) {
+const emptyToUndefined = ({ value }: { value: unknown }) =>
+  value === '' || value === null ? undefined : value;
+
+const optionalNumber = ({ value }: { value: unknown }) => {
+  if (value === '' || value === null || value === undefined) {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isNaN(parsedValue) ? value : parsedValue;
+};
+
+const optionalBoolean = ({ value }: { value: unknown }) => {
+  if (value === '' || value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return value;
+};
+
+export class UpdateDonationDto {
   @IsOptional()
-  @Type(() => Number)
+  @Transform(emptyToUndefined)
+  @IsUUID()
+  category_id?: string;
+
+  @IsOptional()
+  @Transform(emptyToUndefined)
+  @IsString()
+  @MaxLength(60)
+  name?: string;
+
+  @IsOptional()
+  @Transform(emptyToUndefined)
+  @IsString()
+  @MaxLength(250)
+  description?: string;
+
+  @IsOptional()
+  @Transform(optionalNumber)
+  @IsNumber()
+  initial_quantity?: number;
+
+  @IsOptional()
+  @Transform(optionalNumber)
   @IsNumber()
   current_quantity?: number;
 
   @IsOptional()
+  @Transform(emptyToUndefined)
+  @IsString()
+  @MaxLength(90)
+  donator_name?: string;
+
+  @IsOptional()
+  @Transform(emptyToUndefined)
+  @IsString()
+  @MaxLength(10)
+  gender?: string;
+
+  @IsOptional()
+  @Transform(emptyToUndefined)
+  @IsString()
+  @MaxLength(20)
+  size?: string;
+
+  @IsOptional()
+  @Transform(optionalBoolean)
   @IsBoolean()
   active?: boolean;
 
   @IsOptional()
+  @Transform(optionalBoolean)
   @IsBoolean()
   available?: boolean;
 }


### PR DESCRIPTION
## Summary
- replace donation update DTO inheritance with an explicit optional update DTO
- treat empty strings from forms/multipart as omitted fields
- add DTO validation tests for empty payloads, empty strings, numbers, and booleans

## Tests
- yarn build
- yarn test update-donation.dto.spec.ts