### PR TITLE
[codex] Add backend role permissions

### DIFF
--- a/src/modules/category/controllers/category.controller.ts
+++ b/src/modules/category/controllers/category.controller.ts
@@ -24,13 +24,17 @@ import { CreateCategoryDto } from '../dtos/create-category.dto';
 import { UpdateCategoryDto } from '../dtos/update-category.dto';
 import { CategoryResponseDto } from '../dtos/category.response.dto';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
+import { RolesGuard } from '@/common/guards/roles.guard';
+import { Roles } from '@/common/decorator/roles.decorator';
+import { EmployeeRole } from '@/modules/employee/enums/role.enum';
 
 @ApiTags('Categories')
 @Controller('categories')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @ApiBearerAuth()
   @Post()
   @HttpCode(HttpStatus.CREATED)
@@ -43,7 +47,8 @@ export class CategoryController {
     return this.categoryService.create(createCategoryDto);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Get()
   @ApiOperation({ summary: 'Listar todas as categorias' })
@@ -55,7 +60,8 @@ export class CategoryController {
     return this.categoryService.findAll();
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Get(':id')
   @ApiOperation({ summary: 'Buscar uma categoria pelo ID' })
@@ -66,7 +72,8 @@ export class CategoryController {
     return this.categoryService.findById(id);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @ApiBearerAuth()
   @Put(':id')
   @ApiOperation({ summary: 'Atualizar uma categoria' })
@@ -80,7 +87,8 @@ export class CategoryController {
     return this.categoryService.update(id, updateCategoryDto);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @ApiBearerAuth()
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -7,6 +7,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
+import { LoggedUser } from '@/common/decorator/user.decorator';
+import { Employee } from '@prisma/client';
 import { DashboardService } from './dashboard.service';
 import {
   DASHBOARD_PERIODS,
@@ -32,7 +34,10 @@ export class DashboardController {
     status: 200,
     description: 'Indicadores do dashboard retornados com sucesso',
   })
-  getOverview(@Query() query: DashboardOverviewQueryDto) {
-    return this.dashboardService.getOverview(query.period ?? 'year');
+  getOverview(
+    @Query() query: DashboardOverviewQueryDto,
+    @LoggedUser() employee: Employee
+  ) {
+    return this.dashboardService.getOverview(query.period ?? 'year', employee.role);
   }
 }

--- a/src/modules/dashboard/dashboard.service.spec.ts
+++ b/src/modules/dashboard/dashboard.service.spec.ts
@@ -149,4 +149,31 @@ describe('DashboardService', () => {
     expect(result.lists.upcoming_events).toHaveLength(1);
     expect(result.lists.recent_families).toHaveLength(2);
   });
+
+  it('remove métricas sensíveis do dashboard de voluntário', async () => {
+    const now = new Date();
+    prisma.family.findMany.mockResolvedValue([
+      {
+        id: 'family-1',
+        name: 'Família Souza',
+        city: 'Sorocaba',
+        neighborhood: 'Centro',
+        created_at: now,
+      },
+    ]);
+    prisma.employee.findMany.mockResolvedValue([
+      { id: 'employee-1', role: EmployeeRole.ADMIN },
+    ]);
+    prisma.event.findMany.mockResolvedValue([]);
+    prisma.donation.findMany.mockResolvedValue([]);
+
+    const result = await service.getOverview('year', EmployeeRole.VOLUNTEER);
+
+    expect(result.summary).not.toHaveProperty('active_employees');
+    expect(result.summary).not.toHaveProperty('employees_by_role');
+    expect(result.lists).not.toHaveProperty('recent_donations');
+    expect(result.lists).not.toHaveProperty('recent_families');
+    expect(result.lists.upcoming_events).toEqual([]);
+    expect(result.lists.critical_stock).toEqual([]);
+  });
 });

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/config/prisma/prisma.service';
 import { DashboardPeriod } from './dto/dashboard-overview-query.dto';
+import { EmployeeRole } from '@prisma/client';
 
 type SupportedStatus = 'ABERTO' | 'CONCLUIDO' | 'CANCELADO' | 'OUTROS';
 
@@ -24,7 +25,7 @@ interface DashboardEventRow {
 export class DashboardService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getOverview(period: DashboardPeriod = 'year') {
+  async getOverview(period: DashboardPeriod = 'year', role?: EmployeeRole) {
     const now = new Date();
     const bucketConfig = this.buildBucketConfig(period, now);
 
@@ -175,7 +176,7 @@ export class DashboardService {
       .sort((a, b) => b[1] - a[1])
       .slice(0, 10);
 
-    return {
+    const overview = {
       period,
       generated_at: now.toISOString(),
       summary: {
@@ -257,6 +258,15 @@ export class DashboardService {
         })),
       },
     };
+
+    if (role === EmployeeRole.VOLUNTEER) {
+      delete (overview.summary as any).active_employees;
+      delete (overview.summary as any).employees_by_role;
+      delete (overview.lists as any).recent_donations;
+      delete (overview.lists as any).recent_families;
+    }
+
+    return overview;
   }
 
   private createSeries(bucketConfig: BucketConfig, dates: Date[]) {

--- a/src/modules/donation/controllers/donation.controller.ts
+++ b/src/modules/donation/controllers/donation.controller.ts
@@ -24,6 +24,11 @@ import { DonationService } from '../services/donation.service';
 import { CreateDonationDto } from '../dtos/create-donation.dto';
 import { UpdateDonationDto } from '../dtos/update-donation.dto';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
+import { RolesGuard } from '@/common/guards/roles.guard';
+import { Roles } from '@/common/decorator/roles.decorator';
+import { EmployeeRole } from '@/modules/employee/enums/role.enum';
+import { LoggedUser } from '@/common/decorator/user.decorator';
+import { Employee } from '@prisma/client';
 
 const DONATION_IMAGE_MAX_SIZE_BYTES = 10 * 1024 * 1024;
 
@@ -141,11 +146,14 @@ export class DonationController {
   update(
     @Param('id') id: string,
     @Body() updateDonationDto: UpdateDonationDto,
-    @UploadedFile() image?: Express.Multer.File
+    @UploadedFile() image?: Express.Multer.File,
+    @LoggedUser() employee?: Employee
   ) {
-    return this.donationService.update(id, updateDonationDto, image);
+    return this.donationService.update(id, updateDonationDto, image, employee);
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Delete(':id')
   @ApiOperation({ summary: 'Deletar uma doação' })
   delete(@Param('id') id: string) {

--- a/src/modules/donation/services/donation.service.spec.ts
+++ b/src/modules/donation/services/donation.service.spec.ts
@@ -1,7 +1,12 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { DonationService } from './donation.service';
 import { DonationRepository } from '../repositories/donation.repository';
 import { DonationImageService } from './donation-image.service';
+import { EmployeeRole } from '@prisma/client';
 
 describe('DonationService', () => {
   let repository: jest.Mocked<DonationRepository>;
@@ -93,5 +98,19 @@ describe('DonationService', () => {
 
     expect(repository.findById).toHaveBeenCalledWith('d1');
     expect(repository.delete).toHaveBeenCalledWith('d1');
+  });
+
+  it('bloqueia voluntário ao enviar active na atualização', async () => {
+    repository.findById.mockResolvedValue({ id: 'd1' } as any);
+
+    await expect(
+      service.update(
+        'd1',
+        { active: false },
+        undefined,
+        { role: EmployeeRole.VOLUNTEER } as any
+      )
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(repository.update).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/donation/services/donation.service.ts
+++ b/src/modules/donation/services/donation.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { DonationRepository } from '../repositories/donation.repository';
 import { CreateDonationDto } from '../dtos/create-donation.dto';
@@ -10,6 +11,7 @@ import {
   DonationImageMetadata,
   DonationImageService,
 } from './donation-image.service';
+import { Employee, EmployeeRole } from '@prisma/client';
 
 type DonationWithImage = {
   image_key?: string | null;
@@ -81,9 +83,19 @@ export class DonationService {
   async update(
     id: string,
     updateDonationDto: UpdateDonationDto,
-    image?: Express.Multer.File
+    image?: Express.Multer.File,
+    actor?: Employee
   ) {
     await this.getActiveDonationOrThrow(id);
+
+    if (
+      actor?.role === EmployeeRole.VOLUNTEER &&
+      updateDonationDto.active !== undefined
+    ) {
+      throw new ForbiddenException(
+        'Voluntários não podem desativar ou reativar doações.'
+      );
+    }
 
     const imageMetadata = await this.uploadImageIfPresent(image);
     const donation = await this.donationRepository.update(id, {

--- a/src/modules/employee/controllers/employee.controller.ts
+++ b/src/modules/employee/controllers/employee.controller.ts
@@ -5,13 +5,17 @@ import {
   Body,
   Param,
   Put,
+  Patch,
   Delete,
   UseGuards,
   Query,
 } from '@nestjs/common';
 import { EmployeeService } from '../services/employee.service';
 import { CreateEmployeeDto } from '../dtos/create-employee.dto';
-import { UpdateEmployeeDto } from '../dtos/update-employee.dto';
+import { UpdateEmployeeBasicDto } from '../dtos/update-employee-basic.dto';
+import { UpdateEmployeeRoleDto } from '../dtos/update-employee-role.dto';
+import { UpdateEmployeePasswordDto } from '../dtos/update-employee-password.dto';
+import { UpdateOwnPasswordDto } from '../dtos/update-own-password.dto';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
 import { RolesGuard } from '@/common/guards/roles.guard';
 import { Roles } from '@/common/decorator/roles.decorator';
@@ -41,19 +45,21 @@ export class EmployeeController {
     status: 403,
     description: 'Acesso negado (nível de permissão insuficiente)',
   })
-  create(@Body() dto: CreateEmployeeDto) {
-    return this.employeeService.create(dto);
+  create(@Body() dto: CreateEmployeeDto, @LoggedUser() employee: Employee) {
+    return this.employeeService.create(dto, employee);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Get()
   @ApiOperation({ summary: 'Listar funcionários ativos' })
   @ApiResponse({ status: 200, description: 'Lista de funcionários ativos' })
-  findAllActives() {
-    return this.employeeService.findAllActives();
+  findAllActives(@LoggedUser() employee: Employee) {
+    return this.employeeService.findAllActives(employee);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Get('paginated')
   @ApiOperation({ summary: 'Listar funcionários com paginação' })
   @ApiResponse({
@@ -72,44 +78,111 @@ export class EmployeeController {
   })
   findAllPaginated(
     @Query('page') page?: string,
-    @Query('size') size?: string
+    @Query('size') size?: string,
+    @LoggedUser() employee?: Employee
   ) {
     const pageNumber = page ? parseInt(page, 10) : 1;
     const pageSize = size ? parseInt(size, 10) : 10;
-    return this.employeeService.findAllPaginated(pageNumber, pageSize);
+    return this.employeeService.findAllPaginated(
+      pageNumber,
+      pageSize,
+      employee
+    );
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Get('all')
   @ApiOperation({ summary: 'Listar todos os funcionários' })
   @ApiResponse({ status: 200, description: 'Lista de funcionários' })
-  findAll() {
-    return this.employeeService.findAll();
+  findAll(@LoggedUser() employee: Employee) {
+    return this.employeeService.findAll(employee);
   }
 
   @UseGuards(JwtAuthGuard)
   @Get('profile')
   getProfile(@LoggedUser() employee: Employee) {
-    return employee;
+    const { password: _password, ...safeEmployee } = employee;
+    return safeEmployee;
   }
 
   @UseGuards(JwtAuthGuard)
+  @Patch('me')
+  @ApiOperation({ summary: 'Atualizar o próprio perfil' })
+  updateOwnProfile(
+    @LoggedUser() employee: Employee,
+    @Body() dto: UpdateEmployeeBasicDto
+  ) {
+    return this.employeeService.updateOwnProfile(employee, dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('me/password')
+  @ApiOperation({ summary: 'Alterar a própria senha' })
+  updateOwnPassword(
+    @LoggedUser() employee: Employee,
+    @Body() dto: UpdateOwnPasswordDto
+  ) {
+    return this.employeeService.updateOwnPassword(
+      employee,
+      dto.current_password,
+      dto.new_password
+    );
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Get(':id')
   @ApiOperation({ summary: 'Buscar funcionário por ID' })
-  findOne(@Param('id') id: string) {
-    return this.employeeService.findOne(id);
+  findOne(@Param('id') id: string, @LoggedUser() employee: Employee) {
+    return this.employeeService.findOne(id, employee);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
+  @Put(':id/basic')
+  @ApiOperation({ summary: 'Atualizar dados básicos de funcionário' })
+  @ApiResponse({
+    status: 403,
+    description: 'Acesso negado (nível de permissão insuficiente)',
+  })
+  updateBasic(
+    @Param('id') id: string,
+    @Body() dto: UpdateEmployeeBasicDto,
+    @LoggedUser() employee: Employee
+  ) {
+    return this.employeeService.updateBasic(id, dto, employee);
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Put(':id')
-  @ApiOperation({ summary: 'Atualizar funcionário' })
-  @ApiResponse({
-    status: 403,
-    description: 'Acesso negado (nível de permissão insuficiente)',
-  })
-  update(@Param('id') id: string, @Body() dto: UpdateEmployeeDto) {
-    return this.employeeService.update(id, dto);
+  @ApiOperation({ summary: 'Atualizar dados básicos de funcionário' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateEmployeeBasicDto,
+    @LoggedUser() employee: Employee
+  ) {
+    return this.employeeService.updateBasic(id, dto, employee);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN)
+  @Patch(':id/role')
+  @ApiOperation({ summary: 'Alterar nível de acesso de funcionário' })
+  updateRole(@Param('id') id: string, @Body() dto: UpdateEmployeeRoleDto) {
+    return this.employeeService.updateRole(id, dto.role);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN)
+  @Patch(':id/password')
+  @ApiOperation({ summary: 'Alterar senha de outro funcionário' })
+  updatePassword(
+    @Param('id') id: string,
+    @Body() dto: UpdateEmployeePasswordDto
+  ) {
+    return this.employeeService.updatePassword(id, dto.password);
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/src/modules/employee/dtos/create-employee.dto.ts
+++ b/src/modules/employee/dtos/create-employee.dto.ts
@@ -126,6 +126,14 @@ export class CreateEmployeeDto {
   state: string;
 
   @ApiPropertyOptional({
+    example: 'Apto 45',
+    description: 'Complemento do endereço',
+  })
+  @IsOptional()
+  @IsString()
+  complement?: string;
+
+  @ApiPropertyOptional({
     example: true,
     description: 'Define se o funcionário está ativo',
     default: true,

--- a/src/modules/employee/dtos/update-employee-basic.dto.ts
+++ b/src/modules/employee/dtos/update-employee-basic.dto.ts
@@ -1,19 +1,13 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateEmployeeDto } from './create-employee.dto';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import {
-  IsOptional,
-  IsBoolean,
   IsDateString,
   IsEmail,
-  IsEnum,
   IsNotEmpty,
+  IsOptional,
   IsString,
-  Length,
 } from 'class-validator';
-import { EmployeeRole } from '@prisma/client';
 
-export class UpdateEmployeeDto extends PartialType(CreateEmployeeDto) {
+export class UpdateEmployeeBasicDto {
   @ApiPropertyOptional({ example: 'João' })
   @IsOptional()
   @IsString()
@@ -31,7 +25,7 @@ export class UpdateEmployeeDto extends PartialType(CreateEmployeeDto) {
   @IsDateString()
   birth_date?: string;
 
-  @ApiPropertyOptional({ example: '123.456.789-00' })
+  @ApiPropertyOptional({ example: '12345678900' })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
@@ -47,20 +41,6 @@ export class UpdateEmployeeDto extends PartialType(CreateEmployeeDto) {
   @IsString()
   @IsNotEmpty()
   phone?: string;
-
-  @ApiPropertyOptional({ example: 'novaSenha123' })
-  @IsOptional()
-  @IsString()
-  @Length(6, 20)
-  password?: string;
-
-  @ApiPropertyOptional({
-    enum: EmployeeRole,
-    example: EmployeeRole.ADMIN,
-  })
-  @IsOptional()
-  @IsEnum(EmployeeRole)
-  role?: EmployeeRole;
 
   @ApiPropertyOptional({ example: '01001-000' })
   @IsOptional()
@@ -102,9 +82,4 @@ export class UpdateEmployeeDto extends PartialType(CreateEmployeeDto) {
   @IsOptional()
   @IsString()
   complement?: string;
-
-  @ApiPropertyOptional({ example: true })
-  @IsOptional()
-  @IsBoolean()
-  active?: boolean;
 }

--- a/src/modules/employee/dtos/update-employee-password.dto.ts
+++ b/src/modules/employee/dtos/update-employee-password.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Length } from 'class-validator';
+
+export class UpdateEmployeePasswordDto {
+  @ApiProperty({ example: 'novaSenha123' })
+  @IsString()
+  @Length(8, 128)
+  password: string;
+}

--- a/src/modules/employee/dtos/update-employee-role.dto.ts
+++ b/src/modules/employee/dtos/update-employee-role.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EmployeeRole } from '@prisma/client';
+import { IsEnum } from 'class-validator';
+
+export class UpdateEmployeeRoleDto {
+  @ApiProperty({
+    enum: EmployeeRole,
+    example: EmployeeRole.VOLUNTEER,
+    description: 'Novo papel do funcionário no sistema',
+  })
+  @IsEnum(EmployeeRole)
+  role: EmployeeRole;
+}

--- a/src/modules/employee/dtos/update-own-password.dto.ts
+++ b/src/modules/employee/dtos/update-own-password.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Length } from 'class-validator';
+
+export class UpdateOwnPasswordDto {
+  @ApiProperty({ example: 'senhaAtual123' })
+  @IsString()
+  current_password: string;
+
+  @ApiProperty({ example: 'novaSenha123' })
+  @IsString()
+  @Length(8, 128)
+  new_password: string;
+}

--- a/src/modules/employee/repositories/employee.repository.interface.ts
+++ b/src/modules/employee/repositories/employee.repository.interface.ts
@@ -1,16 +1,15 @@
-import { Employee } from '@prisma/client';
+import { Employee, EmployeeRole, Prisma } from '@prisma/client';
 import { CreateEmployeeDto } from '../dtos/create-employee.dto';
-import { UpdateEmployeeDto } from '../dtos/update-employee.dto';
 
 export interface EmployeeRepository {
   create(dto: CreateEmployeeDto, hashedPassword: string): Promise<Employee>;
   findAll(): Promise<Employee[]>;
-  findAllActives(): Promise<Employee[]>;
+  findAllActives(role?: EmployeeRole): Promise<Employee[]>;
   findById(id: string): Promise<Employee | null>;
   findByEmail(email: string): Promise<Employee | null>;
   findByCpf(cpf: string): Promise<Employee | null>;
-  update(id: string, data: UpdateEmployeeDto): Promise<Employee>;
+  update(id: string, data: Prisma.EmployeeUpdateInput): Promise<Employee>;
   softDelete(id: string): Promise<Employee>;
-  findPaginated(skip: number, take: number): Promise<Employee[]>;
-  countActives(): Promise<number>;
+  findPaginated(skip: number, take: number, role?: EmployeeRole): Promise<Employee[]>;
+  countActives(role?: EmployeeRole): Promise<number>;
 }

--- a/src/modules/employee/repositories/employee.repository.ts
+++ b/src/modules/employee/repositories/employee.repository.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/config/prisma/prisma.service';
 import { EmployeeRepository } from './employee.repository.interface';
 import { CreateEmployeeDto } from '../dtos/create-employee.dto';
-import { UpdateEmployeeDto } from '../dtos/update-employee.dto';
-import { Employee } from '@prisma/client';
+import { Employee, EmployeeRole, Prisma } from '@prisma/client';
 
 @Injectable()
 export class EmployeeRepositoryImpl implements EmployeeRepository {
@@ -25,8 +24,10 @@ export class EmployeeRepositoryImpl implements EmployeeRepository {
     return this.prisma.employee.findMany();
   }
 
-  findAllActives(): Promise<Employee[]> {
-    return this.prisma.employee.findMany({ where: { active: true } });
+  findAllActives(role?: EmployeeRole): Promise<Employee[]> {
+    return this.prisma.employee.findMany({
+      where: { active: true, ...(role ? { role } : {}) },
+    });
   }
 
   findById(id: string): Promise<Employee | null> {
@@ -41,7 +42,7 @@ export class EmployeeRepositoryImpl implements EmployeeRepository {
     return this.prisma.employee.findUnique({ where: { cpf } });
   }
 
-  update(id: string, data: UpdateEmployeeDto): Promise<Employee> {
+  update(id: string, data: Prisma.EmployeeUpdateInput): Promise<Employee> {
     return this.prisma.employee.update({ where: { id }, data });
   }
 
@@ -52,16 +53,22 @@ export class EmployeeRepositoryImpl implements EmployeeRepository {
     });
   }
 
-  findPaginated(skip: number, take: number): Promise<Employee[]> {
+  findPaginated(
+    skip: number,
+    take: number,
+    role?: EmployeeRole
+  ): Promise<Employee[]> {
     return this.prisma.employee.findMany({
-      where: { active: true },
+      where: { active: true, ...(role ? { role } : {}) },
       orderBy: { created_at: 'desc' },
       skip,
       take,
     });
   }
 
-  countActives(): Promise<number> {
-    return this.prisma.employee.count({ where: { active: true } });
+  countActives(role?: EmployeeRole): Promise<number> {
+    return this.prisma.employee.count({
+      where: { active: true, ...(role ? { role } : {}) },
+    });
   }
 }

--- a/src/modules/employee/services/employee.service.spec.ts
+++ b/src/modules/employee/services/employee.service.spec.ts
@@ -62,7 +62,7 @@ describe('EmployeeService', () => {
 
     const result = await service.findAllPaginated(2, 2);
 
-    expect(repository.findPaginated).toHaveBeenCalledWith(2, 2);
+    expect(repository.findPaginated).toHaveBeenCalledWith(2, 2, undefined);
     expect(result).toEqual(
       expect.objectContaining({
         page: 2,
@@ -80,5 +80,32 @@ describe('EmployeeService', () => {
     const result = await service.remove('e1');
     expect(disableUseCase.execute).toHaveBeenCalledWith('e1');
     expect(result).toEqual({ id: 'e1', active: false });
+  });
+
+  it('filtra paginação de gerente para voluntários', async () => {
+    repository.findPaginated.mockResolvedValue([{ id: 'e1' } as any]);
+    repository.countActives.mockResolvedValue(1);
+
+    await service.findAllPaginated(1, 10, {
+      role: 'MANAGER',
+    } as any);
+
+    expect(repository.findPaginated).toHaveBeenCalledWith(0, 10, 'VOLUNTEER');
+    expect(repository.countActives).toHaveBeenCalledWith('VOLUNTEER');
+  });
+
+  it('bloqueia gerente ao editar funcionário que não é voluntário', async () => {
+    repository.findById.mockResolvedValue({
+      id: 'manager-2',
+      role: 'MANAGER',
+    } as any);
+
+    await expect(
+      service.updateBasic(
+        'manager-2',
+        { name: 'Novo' },
+        { role: 'MANAGER' } as any
+      )
+    ).rejects.toThrow('Gerentes só podem gerenciar voluntários.');
   });
 });

--- a/src/modules/employee/services/employee.service.ts
+++ b/src/modules/employee/services/employee.service.ts
@@ -1,16 +1,21 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Inject,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
 import { EmployeeRepository } from '../repositories/employee.repository.interface';
 import { CreateEmployeeDto } from '../dtos/create-employee.dto';
 import { UpdateEmployeeDto } from '../dtos/update-employee.dto';
+import { UpdateEmployeeBasicDto } from '../dtos/update-employee-basic.dto';
 import { ErrorMessages } from '@/common/helper/error-messages';
 import { CreateEmployeeUseCase } from '../use-cases/create-employee.use-case';
 import { UpdateEmployeeUseCase } from '../use-cases/update-employee.use-case';
 import { DisableEmployeeUseCase } from '../use-cases/disable-employee.use-case';
+import { Employee, EmployeeRole, Prisma } from '@prisma/client';
 
 @Injectable()
 export class EmployeeService {
@@ -22,24 +27,42 @@ export class EmployeeService {
     private readonly disableEmployee: DisableEmployeeUseCase
   ) {}
 
-  async create(dto: CreateEmployeeDto) {
-    return this.createEmployee.execute(dto);
+  async create(dto: CreateEmployeeDto, actor?: Employee) {
+    if (
+      actor?.role === EmployeeRole.MANAGER &&
+      dto.role !== EmployeeRole.VOLUNTEER
+    ) {
+      throw new ForbiddenException('Gerentes só podem cadastrar voluntários.');
+    }
+
+    const employee = await this.createEmployee.execute(dto);
+    return this.sanitizeEmployee(employee);
   }
 
-  async findAll() {
-    return this.repository.findAll();
+  async findAll(actor?: Employee) {
+    if (actor?.role === EmployeeRole.MANAGER) {
+      const employees = await this.repository.findAllActives(EmployeeRole.VOLUNTEER);
+      return employees.map((employee) => this.sanitizeEmployee(employee));
+    }
+
+    const employees = await this.repository.findAll();
+    return employees.map((employee) => this.sanitizeEmployee(employee));
   }
 
-  async findAllActives() {
-    return this.repository.findAllActives();
+  async findAllActives(actor?: Employee) {
+    const employees = await this.repository.findAllActives(
+      this.getManagedRoleFilter(actor)
+    );
+    return employees.map((employee) => this.sanitizeEmployee(employee));
   }
 
-  async findAllPaginated(page = 1, size = 10) {
+  async findAllPaginated(page = 1, size = 10, actor?: Employee) {
     const skip = (page - 1) * size;
+    const roleFilter = this.getManagedRoleFilter(actor);
 
     const [employees, total] = await Promise.all([
-      this.repository.findPaginated(skip, size),
-      this.repository.countActives(),
+      this.repository.findPaginated(skip, size, roleFilter),
+      this.repository.countActives(roleFilter),
     ]);
 
     const totalPages = Math.ceil(total / size);
@@ -51,24 +74,125 @@ export class EmployeeService {
       is_last_page: isLastPage,
       previous_page: page > 1 ? page - 1 : 1,
       total_pages: totalPages,
-      list: employees,
+      list: employees.map((employee) => this.sanitizeEmployee(employee)),
     };
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, actor?: Employee) {
     const employee = await this.repository.findById(id);
     if (!employee) {
       throw new NotFoundException(ErrorMessages.EMPLOYEE_NOT_FOUND);
     }
-    return employee;
+
+    this.ensureCanManageEmployee(actor, employee);
+    return this.sanitizeEmployee(employee);
   }
 
   async update(id: string, dto: UpdateEmployeeDto) {
     return this.updateEmployee.execute(id, dto);
   }
 
+  async updateBasic(id: string, dto: UpdateEmployeeBasicDto, actor?: Employee) {
+    const employee = await this.findOne(id, actor);
+    return this.sanitizeEmployee(await this.updateBasicData(employee.id, dto));
+  }
+
+  async updateOwnProfile(employee: Employee, dto: UpdateEmployeeBasicDto) {
+    return this.sanitizeEmployee(await this.updateBasicData(employee.id, dto));
+  }
+
+  async updateRole(id: string, role: EmployeeRole) {
+    await this.findOne(id);
+    return this.sanitizeEmployee(await this.repository.update(id, { role }));
+  }
+
+  async updatePassword(id: string, password: string) {
+    await this.findOne(id);
+    const hashedPassword = await bcrypt.hash(password, 10);
+    return this.sanitizeEmployee(
+      await this.repository.update(id, { password: hashedPassword })
+    );
+  }
+
+  async updateOwnPassword(
+    employee: Employee,
+    currentPassword: string,
+    newPassword: string
+  ) {
+    const isCurrentPasswordValid = await bcrypt.compare(
+      currentPassword,
+      employee.password
+    );
+
+    if (!isCurrentPasswordValid) {
+      throw new UnauthorizedException(ErrorMessages.INVALID_CREDENTIALS);
+    }
+
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+    return this.sanitizeEmployee(
+      await this.repository.update(employee.id, { password: hashedPassword })
+    );
+  }
+
   async remove(id: string) {
-    return this.disableEmployee.execute(id);
+    return this.sanitizeEmployee(await this.disableEmployee.execute(id));
+  }
+
+  private async updateBasicData(id: string, dto: UpdateEmployeeBasicDto) {
+    const existing = await this.repository.findById(id);
+
+    if (!existing) {
+      throw new NotFoundException(ErrorMessages.EMPLOYEE_NOT_FOUND);
+    }
+
+    const cleanedCpf = dto.cpf ? dto.cpf.replace(/\D/g, '') : undefined;
+    const normalizedEmail = dto.email?.toLowerCase();
+
+    if (normalizedEmail && normalizedEmail !== existing.email) {
+      const emailExists = await this.repository.findByEmail(normalizedEmail);
+      if (emailExists) {
+        throw new BadRequestException(ErrorMessages.EMAIL_DUPLICATE);
+      }
+    }
+
+    if (cleanedCpf && cleanedCpf !== existing.cpf) {
+      const cpfExists = await this.repository.findByCpf(cleanedCpf);
+      if (cpfExists) {
+        throw new BadRequestException(ErrorMessages.CPF_DUPLICATE);
+      }
+    }
+
+    const data: Prisma.EmployeeUpdateInput = {
+      ...dto,
+      cpf: cleanedCpf,
+      email: normalizedEmail,
+      birth_date: dto.birth_date ? new Date(dto.birth_date) : undefined,
+    };
+
+    return this.repository.update(id, data);
+  }
+
+  private getManagedRoleFilter(actor?: Employee) {
+    return actor?.role === EmployeeRole.MANAGER
+      ? EmployeeRole.VOLUNTEER
+      : undefined;
+  }
+
+  private ensureCanManageEmployee(
+    actor: Employee | undefined,
+    employee: Employee
+  ) {
+    if (
+      actor?.role === EmployeeRole.MANAGER &&
+      employee.role !== EmployeeRole.VOLUNTEER
+    ) {
+      throw new ForbiddenException('Gerentes só podem gerenciar voluntários.');
+    }
+  }
+
+  private sanitizeEmployee<T extends Partial<Employee>>(employee: T) {
+    const { password: _password, ...safeEmployee } = employee;
+    return safeEmployee;
   }
 
   private async ensureUniqueFields(email: string, cpf: string) {

--- a/src/modules/event/dto/update-event-attendance.dto.ts
+++ b/src/modules/event/dto/update-event-attendance.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class UpdateEventAttendanceDto {
+  @ApiProperty({ example: 120 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  attendance: number;
+}

--- a/src/modules/event/dto/update-event-basic.dto.ts
+++ b/src/modules/event/dto/update-event-basic.dto.ts
@@ -1,0 +1,63 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class UpdateEventBasicDto {
+  @ApiPropertyOptional({ example: 'Campanha de Natal' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'Evento para doação de brinquedos' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ example: '2025-12-24T18:00:00Z' })
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+
+  @ApiPropertyOptional({ example: 'Seja bem-vindo ao nosso evento!' })
+  @IsOptional()
+  @IsString()
+  greeting_description?: string;
+
+  @ApiPropertyOptional({ example: '01001-000' })
+  @IsOptional()
+  @IsString()
+  cep?: string;
+
+  @ApiPropertyOptional({ example: 'Rua das Flores' })
+  @IsOptional()
+  @IsString()
+  street?: string;
+
+  @ApiPropertyOptional({ example: 'Centro' })
+  @IsOptional()
+  @IsString()
+  neighborhood?: string;
+
+  @ApiPropertyOptional({ example: '123' })
+  @IsOptional()
+  @IsString()
+  number?: string;
+
+  @ApiPropertyOptional({ example: 'São Paulo' })
+  @IsOptional()
+  @IsString()
+  city?: string;
+
+  @ApiPropertyOptional({ example: 'São Paulo' })
+  @IsOptional()
+  @IsString()
+  state?: string;
+
+  @ApiPropertyOptional({ example: 'Próximo à praça' })
+  @IsOptional()
+  @IsString()
+  complement?: string;
+}

--- a/src/modules/event/dto/update-event-instagram.dto.ts
+++ b/src/modules/event/dto/update-event-instagram.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateEventInstagramDto {
+  @ApiPropertyOptional({ example: 'https://www.instagram.com/p/DKZm15CskZp/' })
+  @IsOptional()
+  @IsString()
+  embedded_instagram?: string;
+}

--- a/src/modules/event/dto/update-event-status.dto.ts
+++ b/src/modules/event/dto/update-event-status.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EventStatus } from '@prisma/client';
+import { IsEnum } from 'class-validator';
+
+export class UpdateEventStatusDto {
+  @ApiProperty({
+    enum: EventStatus,
+    example: EventStatus.COMPLETED,
+    description: 'Novo status do evento',
+  })
+  @IsEnum(EventStatus)
+  status: EventStatus;
+}

--- a/src/modules/event/event.controller.ts
+++ b/src/modules/event/event.controller.ts
@@ -5,6 +5,7 @@ import {
   Body,
   Param,
   Put,
+  Patch,
   Delete,
   UseGuards,
   Query,
@@ -17,11 +18,16 @@ import {
 } from '@nestjs/swagger';
 import { EventService } from './event.service';
 import { CreateEventDto } from './dto/create-event.dto';
-import { UpdateEventDto } from './dto/update-event.dto';
+import { UpdateEventBasicDto } from './dto/update-event-basic.dto';
+import { UpdateEventStatusDto } from './dto/update-event-status.dto';
+import { UpdateEventAttendanceDto } from './dto/update-event-attendance.dto';
+import { UpdateEventInstagramDto } from './dto/update-event-instagram.dto';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
 import { RolesGuard } from '@/common/guards/roles.guard';
 import { Roles } from '@/common/decorator/roles.decorator';
 import { EmployeeRole } from '@/modules/employee/enums/role.enum';
+import { LoggedUser } from '@/common/decorator/user.decorator';
+import { Employee } from '@prisma/client';
 
 @ApiTags('Events')
 @Controller('events')
@@ -125,14 +131,52 @@ export class EventController {
     return this.eventService.findOne(id);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Put(':id')
-  @ApiOperation({ summary: 'Atualizar evento por ID' })
+  @ApiOperation({ summary: 'Atualizar dados básicos do evento por ID' })
   @ApiResponse({ status: 200, description: 'Evento atualizado com sucesso' })
   @ApiResponse({ status: 404, description: 'Evento não encontrado' })
-  update(@Param('id') id: string, @Body() dto: UpdateEventDto) {
+  update(@Param('id') id: string, @Body() dto: UpdateEventBasicDto) {
     return this.eventService.update(id, dto);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
+  @ApiBearerAuth()
+  @Patch(':id/status')
+  @ApiOperation({ summary: 'Atualizar status do evento' })
+  updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateEventStatusDto,
+    @LoggedUser() employee: Employee
+  ) {
+    return this.eventService.updateStatus(id, dto.status, employee);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
+  @ApiBearerAuth()
+  @Patch(':id/attendance')
+  @ApiOperation({ summary: 'Atualizar presença do evento' })
+  updateAttendance(
+    @Param('id') id: string,
+    @Body() dto: UpdateEventAttendanceDto
+  ) {
+    return this.eventService.updateAttendance(id, dto.attendance);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
+  @ApiBearerAuth()
+  @Patch(':id/instagram')
+  @ApiOperation({ summary: 'Atualizar post do Instagram do evento' })
+  updateInstagram(
+    @Param('id') id: string,
+    @Body() dto: UpdateEventInstagramDto
+  ) {
+    return this.eventService.updateInstagram(id, dto.embedded_instagram);
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/src/modules/event/event.service.spec.ts
+++ b/src/modules/event/event.service.spec.ts
@@ -1,7 +1,8 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { EventService } from './event.service';
 import { PrismaService } from '@/config/prisma/prisma.service';
 import { InstagramContentService } from './services/instagram-content.service';
+import { EmployeeRole, EventStatus } from '@prisma/client';
 
 describe('EventService', () => {
   let prisma: {
@@ -127,5 +128,57 @@ describe('EventService', () => {
         list: [{ id: '1' }],
       })
     );
+  });
+
+  it('permite voluntário marcar evento como concluído', async () => {
+    prisma.event.findUnique.mockResolvedValue({ id: 'event-1' });
+    prisma.event.update.mockResolvedValue({
+      id: 'event-1',
+      status: EventStatus.COMPLETED,
+    });
+
+    const result = await service.updateStatus(
+      'event-1',
+      EventStatus.COMPLETED,
+      { role: EmployeeRole.VOLUNTEER } as any
+    );
+
+    expect(prisma.event.update).toHaveBeenCalledWith({
+      where: { id: 'event-1' },
+      data: { status: EventStatus.COMPLETED },
+    });
+    expect(result.status).toBe(EventStatus.COMPLETED);
+  });
+
+  it('bloqueia voluntário ao cancelar evento', async () => {
+    prisma.event.findUnique.mockResolvedValue({ id: 'event-1' });
+
+    await expect(
+      service.updateStatus('event-1', EventStatus.CANCELED, {
+        role: EmployeeRole.VOLUNTEER,
+      } as any)
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.event.update).not.toHaveBeenCalled();
+  });
+
+  it('valida link do instagram ao atualizar publicação', async () => {
+    prisma.event.findUnique.mockResolvedValue({ id: 'event-1' });
+    instagramContentService.validateUrl.mockReturnValue(
+      'https://www.instagram.com/p/abc/'
+    );
+    prisma.event.update.mockResolvedValue({
+      id: 'event-1',
+      embedded_instagram: 'https://www.instagram.com/p/abc/',
+    });
+
+    await service.updateInstagram('event-1', 'https://instagram.com/p/abc');
+
+    expect(instagramContentService.validateUrl).toHaveBeenCalledWith(
+      'https://instagram.com/p/abc'
+    );
+    expect(prisma.event.update).toHaveBeenCalledWith({
+      where: { id: 'event-1' },
+      data: { embedded_instagram: 'https://www.instagram.com/p/abc/' },
+    });
   });
 });

--- a/src/modules/event/event.service.ts
+++ b/src/modules/event/event.service.ts
@@ -2,12 +2,14 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '@/config/prisma/prisma.service';
 import { CreateEventDto } from './dto/create-event.dto';
-import { UpdateEventDto } from './dto/update-event.dto';
+import { UpdateEventBasicDto } from './dto/update-event-basic.dto';
 import { ErrorMessages } from '@/common/helper/error-messages';
 import { InstagramContentService } from './services/instagram-content.service';
+import { Employee, EmployeeRole, EventStatus } from '@prisma/client';
 
 @Injectable()
 export class EventService {
@@ -55,7 +57,7 @@ export class EventService {
     return event;
   }
 
-  async update(id: string, dto: UpdateEventDto) {
+  async update(id: string, dto: UpdateEventBasicDto) {
     await this.findOne(id);
 
     return this.prisma.event.update({
@@ -64,6 +66,43 @@ export class EventService {
         ...dto,
         date: dto.date ? new Date(dto.date) : undefined,
       },
+    });
+  }
+
+  async updateStatus(id: string, status: EventStatus, actor: Employee) {
+    await this.findOne(id);
+
+    if (actor.role === EmployeeRole.VOLUNTEER && status !== EventStatus.COMPLETED) {
+      throw new ForbiddenException(
+        'Voluntários só podem marcar eventos como concluídos.'
+      );
+    }
+
+    return this.prisma.event.update({
+      where: { id },
+      data: { status },
+    });
+  }
+
+  async updateAttendance(id: string, attendance: number) {
+    await this.findOne(id);
+
+    return this.prisma.event.update({
+      where: { id },
+      data: { attendance },
+    });
+  }
+
+  async updateInstagram(id: string, embeddedInstagram?: string) {
+    await this.findOne(id);
+
+    const normalizedInstagram = embeddedInstagram
+      ? this.instagramContentService.validateUrl(embeddedInstagram)
+      : null;
+
+    return this.prisma.event.update({
+      where: { id },
+      data: { embedded_instagram: normalizedInstagram },
     });
   }
 

--- a/src/modules/family/family.controller.ts
+++ b/src/modules/family/family.controller.ts
@@ -19,13 +19,17 @@ import { FamilyService } from './family.service';
 import { CreateFamilyDto } from './dto/create-family.dto';
 import { UpdateFamilyDto } from './dto/update-family.dto';
 import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
+import { RolesGuard } from '@/common/guards/roles.guard';
+import { Roles } from '@/common/decorator/roles.decorator';
+import { EmployeeRole } from '@/modules/employee/enums/role.enum';
 
 @ApiTags('Families')
 @Controller('families')
 export class FamilyController {
   constructor(private readonly familyService: FamilyService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Post()
   @ApiOperation({ summary: 'Criar nova família' })
@@ -34,7 +38,8 @@ export class FamilyController {
     return this.familyService.create(dto);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Get()
   @ApiOperation({ summary: 'Listar famílias ativas' })
@@ -43,7 +48,8 @@ export class FamilyController {
     return this.familyService.findAllActives();
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Get('paginated')
   @ApiOperation({ summary: 'Listar famílias com paginação' })
@@ -70,7 +76,8 @@ export class FamilyController {
     return this.familyService.findAllPaginated(pageNumber, pageSize);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Get('all')
   @ApiOperation({ summary: 'Listar todas as famílias' })
@@ -79,7 +86,8 @@ export class FamilyController {
     return this.familyService.findAll();
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Get(':id')
   @ApiOperation({ summary: 'Buscar família por ID' })
@@ -89,7 +97,8 @@ export class FamilyController {
     return this.familyService.findOne(id);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER, EmployeeRole.VOLUNTEER)
   @ApiBearerAuth()
   @Put(':id')
   @ApiOperation({ summary: 'Atualizar família' })
@@ -98,7 +107,8 @@ export class FamilyController {
     return this.familyService.update(id, dto);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @ApiBearerAuth()
   @Delete(':id')
   @ApiOperation({ summary: 'Desativar família' })

--- a/src/modules/family/family.service.ts
+++ b/src/modules/family/family.service.ts
@@ -8,7 +8,8 @@ export class FamilyService {
   constructor(private familyRepository: FamilyRepositoryImpl) {}
 
   create(dto: CreateFamilyDto) {
-    return this.familyRepository.create(dto);
+    const { active: _active, ...data } = dto;
+    return this.familyRepository.create(data);
   }
 
   findAll() {
@@ -54,7 +55,8 @@ export class FamilyService {
 
   async update(id: string, dto: UpdateFamilyDto) {
     await this.findOne(id);
-    return this.familyRepository.update(id, dto);
+    const { active: _active, ...data } = dto;
+    return this.familyRepository.update(id, data);
   }
 
   async remove(id: string) {

--- a/src/modules/resources/controllers/resources.controller.ts
+++ b/src/modules/resources/controllers/resources.controller.ts
@@ -1,22 +1,30 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ResourcesService } from '../services/resources.service';
 import { RolesResponseDto } from '../dtos/roles-response.dto';
 import { EventStatusResponseDto } from '../dtos/event-status-response.dto';
+import { JwtAuthGuard } from '@/common/guards/jwt-auth.guard';
+import { RolesGuard } from '@/common/guards/roles.guard';
+import { Roles } from '@/common/decorator/roles.decorator';
+import { EmployeeRole } from '@/modules/employee/enums/role.enum';
+import { LoggedUser } from '@/common/decorator/user.decorator';
+import { Employee } from '@prisma/client';
 
 @ApiTags('Resources')
 @Controller('resources')
 export class ResourcesController {
   constructor(private readonly resourcesService: ResourcesService) {}
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(EmployeeRole.ADMIN, EmployeeRole.MANAGER)
   @Get('roles')
   @ApiOperation({ summary: 'Listar todas as roles disponíveis' })
   @ApiOkResponse({
     description: 'Lista de roles retornada com sucesso',
     type: RolesResponseDto,
   })
-  getRoles(): RolesResponseDto {
-    return this.resourcesService.getRoles();
+  getRoles(@LoggedUser() employee: Employee): RolesResponseDto {
+    return this.resourcesService.getRoles(employee.role);
   }
 
   @Get('event-status')

--- a/src/modules/resources/services/resources.service.spec.ts
+++ b/src/modules/resources/services/resources.service.spec.ts
@@ -9,11 +9,19 @@ describe('ResourcesService', () => {
   });
 
   it('retorna roles com labels e valores esperados', () => {
-    const result = service.getRoles();
+    const result = service.getRoles(EmployeeRole.ADMIN);
 
     expect(result.roles).toEqual([
       { label: 'Administrador', value: EmployeeRole.ADMIN },
       { label: 'Gerente', value: EmployeeRole.MANAGER },
+      { label: 'Voluntário', value: EmployeeRole.VOLUNTEER },
+    ]);
+  });
+
+  it('retorna apenas voluntário quando usuário atual é gerente', () => {
+    const result = service.getRoles(EmployeeRole.MANAGER);
+
+    expect(result.roles).toEqual([
       { label: 'Voluntário', value: EmployeeRole.VOLUNTEER },
     ]);
   });

--- a/src/modules/resources/services/resources.service.ts
+++ b/src/modules/resources/services/resources.service.ts
@@ -5,8 +5,11 @@ import { EventStatusResponseDto } from '../dtos/event-status-response.dto';
 
 @Injectable()
 export class ResourcesService {
-  getRoles(): RolesResponseDto {
-    const roles = [
+  getRoles(currentRole: EmployeeRole): RolesResponseDto {
+    const roles =
+      currentRole === EmployeeRole.MANAGER
+        ? [{ label: 'Voluntário', value: EmployeeRole.VOLUNTEER }]
+        : [
       { label: 'Administrador', value: EmployeeRole.ADMIN },
       { label: 'Gerente', value: EmployeeRole.MANAGER },
       { label: 'Voluntário', value: EmployeeRole.VOLUNTEER },


### PR DESCRIPTION
## Summary

- Enforces role-based access in backend controllers for employees, events, families, donations, categories, resources, and dashboard.
- Splits sensitive employee and event updates into dedicated endpoints for role, password, status, attendance, and Instagram publishing.
- Adds a reduced dashboard response for volunteers and blocks volunteer updates to sensitive fields such as donation `active`.
- Adds focused tests for authorization-sensitive behavior.

## Impact

The backend is now the source of truth for administrative permissions. `ADMIN` keeps full access, `MANAGER` is limited to operational management, and `VOLUNTEER` can perform allowed operational actions only.

## Validation

- `yarn test --runInBand`
- `yarn build`