### PR TITLE
hotfix: allow all cors origins

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,37 +9,8 @@ import pino from 'pino-http';
 import { LoggerService } from './common/logger/logger.service';
 import { LoggingInterceptor } from './common/interceptor/logging.interceptor';
 
-const DEFAULT_CORS_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
-
-function normalizeOrigin(origin: string) {
-  return origin.trim().replace(/\/+$/, '');
-}
-
-function getAllowedCorsOrigins() {
-  const configuredOrigins = (process.env.CORS_ORIGINS ?? '')
-    .split(',')
-    .map(normalizeOrigin)
-    .filter(Boolean);
-
-  return configuredOrigins.length > 0
-    ? configuredOrigins
-    : DEFAULT_CORS_ORIGINS;
-}
-
 async function bootstrap() {
-  const allowedCorsOrigins = getAllowedCorsOrigins();
-  const app = await NestFactory.create(AppModule, {
-    cors: {
-      origin: (origin, callback) => {
-        if (!origin || allowedCorsOrigins.includes(normalizeOrigin(origin))) {
-          return callback(null, true);
-        }
-
-        return callback(new Error('Origem bloqueada por CORS'), false);
-      },
-      credentials: true,
-    },
-  });
+  const app = await NestFactory.create(AppModule, { cors: true });
   const logger = app.get(LoggerService); // ✅ simples e funciona
 
   app.useGlobalFilters(new ErrorFilter());


### PR DESCRIPTION
## Summary
- Reverts CORS origin whitelist to allow all origins temporarily
- Restores the previous NestJS `cors: true` behavior to unblock production access

## Validation
- yarn build